### PR TITLE
Added the ability to process failure numbers.

### DIFF
--- a/dicebag.gemspec
+++ b/dicebag.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'dicebag'
-  s.version     = '3.2.2'
+  s.version     = '3.3.0'
   s.date        = '2016-04-25'
   s.licenses    = ['MIT']
   s.summary     = 'Dice Bag: Ruby Dice Rolling Library'

--- a/lib/dicebag.rb
+++ b/lib/dicebag.rb
@@ -105,7 +105,9 @@ module DiceBag
       hash.delete(:options)
     else
       normalize_explode hash
+      normalize_explode_indefinite hash
       normalize_reroll hash
+      normalize_explode_indefinite hash
       normalize_drop_keep hash
       normalize_target hash
       normalize_failure hash
@@ -118,8 +120,19 @@ module DiceBag
   def self.normalize_explode(hash)
     return unless hash[:options].key? :explode
 
-    if hash[:options][:explode] == 1
+    if hash[:options][:explode] == -1
       hash[:options][:explode] = hash[:sides]
+
+      hash[:notes].push("Explode set to #{hash[:sides]}")
+    end
+  end
+
+  # Prevent Explosion abuse.
+  def self.normalize_explode_indefinite(hash)
+    return unless hash[:options].key? :explode_indefinite
+
+    if hash[:options][:explode_indefinite] == -1
+      hash[:options][:explode_indefinite] = hash[:sides]
 
       hash[:notes].push("Explode set to #{hash[:sides]}")
     end
@@ -131,6 +144,17 @@ module DiceBag
 
     if hash[:options][:reroll] >= hash[:sides]
       hash[:options][:reroll] = 0
+
+      hash[:notes].push 'Reroll reset to 0.'
+    end
+  end
+
+  # Prevent Reroll abuse.
+  def self.normalize_reroll_indefinite(hash)
+    return unless hash[:options].key? :reroll_indefinite
+
+    if hash[:options][:reroll_indefinite] >= hash[:sides]
+      hash[:options][:reroll_indefinite] = 0
 
       hash[:notes].push 'Reroll reset to 0.'
     end

--- a/lib/dicebag/parser.rb
+++ b/lib/dicebag/parser.rb
@@ -46,19 +46,23 @@ module DiceBag
     # Note that :explode is allowed to NOT have a number
     # assigned, which will leave it with a nil value. This
     # is handled in the Transform class.
-    rule(:explode) { str('e') >> number?.as(:explode) >> space? }
-    rule(:drop)    { str('d') >> number.as(:drop) >> space? }
-    rule(:keep)    { str('k') >> number.as(:keep) >> space? }
-    rule(:keeplowest) {str('kl') >> number.as(:keeplowest) >> space?}
-    rule(:reroll)  { str('r') >> number.as(:reroll) >> space? }
-    rule(:target)  { str('t') >> number.as(:target) >> space? }
-    rule(:failure) { str('f') >> number.as(:failure) >> space? }
+    #
+    # For whatever reason ei doesn't work here, so I'm ordering the indefinite options as ie
+    rule(:explode)            { str('e') >> number?.as(:explode) >> space? }
+    rule(:explode_indefinite) { str('ie') >> number?.as(:explode_indefinite) >> space? }
+    rule(:drop)               { str('d') >> number.as(:drop) >> space? }
+    rule(:keep)               { str('k') >> number.as(:keep) >> space? }
+    rule(:keeplowest)         {str('kl') >> number.as(:keeplowest) >> space?}
+    rule(:reroll)             { str('r') >> number.as(:reroll) >> space? }
+    rule(:reroll_indefinite)  { str('ir') >> number.as(:reroll_indefinite) >> space? }
+    rule(:target)             { str('t') >> number.as(:target) >> space? }
+    rule(:failure)            { str('f') >> number.as(:failure) >> space? }
 
     # This allows options to be defined in any order and
     # even have more than one of the same option, however
     # only the last option of a given key will be kept.
     rule(:option) do
-      (drop | explode | keep | keeplowest | reroll | target | failure )
+      (drop | explode | explode_indefinite | keep | keeplowest | reroll | reroll_indefinite | target | failure )
     end
 
     rule(:options) { space? >> option.repeat >> space? }

--- a/lib/dicebag/parser.rb
+++ b/lib/dicebag/parser.rb
@@ -49,6 +49,7 @@ module DiceBag
     rule(:explode) { str('e') >> number?.as(:explode) >> space? }
     rule(:drop)    { str('d') >> number.as(:drop) >> space? }
     rule(:keep)    { str('k') >> number.as(:keep) >> space? }
+    rule(:keeplowest) {str('kl') >> number.as(:keeplowest) >> space?}
     rule(:reroll)  { str('r') >> number.as(:reroll) >> space? }
     rule(:target)  { str('t') >> number.as(:target) >> space? }
 
@@ -56,7 +57,7 @@ module DiceBag
     # even have more than one of the same option, however
     # only the last option of a given key will be kept.
     rule(:option) do
-      (drop | explode | keep | reroll | target)
+      (drop | explode | keep | keeplowest | reroll | target)
     end
 
     rule(:options) { space? >> option.repeat >> space? }

--- a/lib/dicebag/roll_part.rb
+++ b/lib/dicebag/roll_part.rb
@@ -20,7 +20,7 @@ module DiceBag
       @notes  = part[:notes] || []
 
       # Our Default Options
-      @options = { explode: 0, drop: 0, keep: 0, reroll: 0, target: 0 }
+      @options = { explode: 0, drop: 0, keep: 0, keeplowest: 0, reroll: 0, target: 0 }
 
       @options.update(part[:options]) if part.key?(:options)
     end
@@ -46,7 +46,18 @@ module DiceBag
     def roll
       generate_results
 
+      if @options[:keeplowest] >= 1
+        @tally = @results.dup
+        @tally.sort!
+        @tally.reverse!
+        @results.sort!
+        handle_keeplowest
+        handle_total
+        return
+      end
+
       @results.sort!
+
       @results.reverse!
 
       # Save the tally in case it's requested later.
@@ -111,6 +122,13 @@ module DiceBag
       return unless @options[:keep] > 0
 
       range = 0...@options[:keep]
+
+      @results = @results.slice range
+    end
+
+    def handle_keeplowest
+      return unless @options[:keeplowest] > 0
+      range = 0...@options[:keeplowest]
 
       @results = @results.slice range
     end

--- a/lib/dicebag/roll_part_string.rb
+++ b/lib/dicebag/roll_part_string.rb
@@ -13,6 +13,7 @@ module RollPartString
     to_s_explode
     to_s_drop
     to_s_keep
+    to_s_keeplowest
     to_s_reroll
     to_s_target
 
@@ -48,6 +49,12 @@ module RollPartString
     return if @options[:keep].zero?
 
     @parts.push format('k%s', @options[:keep])
+  end
+
+  def to_s_keeplowest
+    return if @options[:keeplowest].zero?
+
+    @parts.push format('kl%s', @options[:keeplowest])
   end
 
   def to_s_reroll

--- a/lib/dicebag/roll_part_string.rb
+++ b/lib/dicebag/roll_part_string.rb
@@ -11,10 +11,12 @@ module RollPartString
 
     to_s_xdx
     to_s_explode
+    to_s_explode_indefinite
     to_s_drop
     to_s_keep
     to_s_keeplowest
     to_s_reroll
+    to_s_reroll_indefinite
     to_s_target
     to_s_failure
 
@@ -40,6 +42,14 @@ module RollPartString
     @parts.push format('e%s', e)
   end
 
+  def to_s_explode_indefinite
+    return if @options[:explode_indefinite].zero?
+
+    e = (@options[:explode_indefinite] == sides) ? @options[:explode_indefinite] : ''
+
+    @parts.push format('ie%s', e)
+  end
+
   def to_s_drop
     return if @options[:drop].zero?
 
@@ -62,6 +72,12 @@ module RollPartString
     return if @options[:reroll].zero?
 
     @parts.push format('r%s', @options[:reroll])
+  end
+
+  def to_s_reroll_indefinite
+    return if @options[:reroll_indefinite].zero?
+
+    @parts.push format('ir%s', @options[:reroll_indefinite])
   end
 
   def to_s_target

--- a/lib/dicebag/transform.rb
+++ b/lib/dicebag/transform.rb
@@ -21,12 +21,14 @@ module DiceBag
     rule(keep:    simple(:x)) { { keep:   Integer(x) } }
     rule(keeplowest: simple(:x)) { { keeplowest: Integer(x) } }
     rule(reroll:  simple(:x)) { { reroll: Integer(x) } }
+    rule(reroll_indefinite:  simple(:x)) { { reroll_indefinite: Integer(x) } }
     rule(target:  simple(:x)) { { target: Integer(x) } }
     rule(failure: simple(:x)) { { failure: Integer(x) } }
 
     # Explode is special, in that if it is nil, then it
     # must remain that way.
-    rule(explode: simple(:x)) { { explode: (x ? Integer(x) : 1) } }
+    rule(explode: simple(:x)) { { explode: (x ? Integer(x) : -1) } }
+    rule(explode_indefinite: simple(:x)) { { explode_indefinite: (x ? Integer(x) : -1) } }
 
     # Match a label by itself.
     rule(label: simple(:s)) { [:label, LabelPart.new(String(s))] }

--- a/lib/dicebag/transform.rb
+++ b/lib/dicebag/transform.rb
@@ -19,6 +19,7 @@ module DiceBag
     # sub-hashes.
     rule(drop:    simple(:x)) { { drop:   Integer(x) } }
     rule(keep:    simple(:x)) { { keep:   Integer(x) } }
+    rule(keeplowest: simple(:x)) { { keeplowest: Integer(x) } }
     rule(reroll:  simple(:x)) { { reroll: Integer(x) } }
     rule(target:  simple(:x)) { { target: Integer(x) } }
 

--- a/readme.md
+++ b/readme.md
@@ -116,7 +116,7 @@ beneath in order to count against successes. These work as a sort of
 negitive successes and are totaled together as described above. For example, 
 '5d10 t8 f1' means roll five 10-sided dice and each die that is 8 or higher 
 is a success and subtract each one. (Like in WhiteWolf games.) Because of
-this, the total may be negitive. If this option is given a 0 value,
+this, the total may be negative. If this option is given a 0 value,
 that is the same as not having the option at all; that is, a normal sum
 of all dice in the roll is performed instead.
 

--- a/test/roll_part.rb
+++ b/test/roll_part.rb
@@ -64,7 +64,26 @@ describe DiceBag::RollPart do
       end
 
       it 'should have a tally of 4 items' do
-        @part.tally.size.must_equal 4
+        @part.tally[0].size.must_equal 3
+        @part.tally[1].size.must_equal 1
+      end
+    end
+
+    describe 'with an exploding indefinitely option' do
+      before do
+        @part = xdx('3d6 ie3').first.last
+
+        make_not_so_random!
+
+        @part.roll
+      end
+
+      it 'should have a total of 21' do
+        @part.total.must_equal 21
+      end
+
+      it 'should explode 5 times' do
+        @part.tally.size.must_equal 5
       end
     end
 
@@ -122,7 +141,7 @@ describe DiceBag::RollPart do
 
     describe 'with an exploding option' do
       before do
-        @part = xdx('3d6 e6 t4').first.last
+        @part = xdx('3d6 e1 t4').first.last
 
         make_not_so_random!
 
@@ -130,11 +149,12 @@ describe DiceBag::RollPart do
       end
 
       it 'should have a total of 2' do
-        @part.total.must_equal 2
+        @part.total.must_equal 3
       end
 
-      it 'should have a tally of 4 items' do
-        @part.tally.size.must_equal 4
+      it 'should have a tally of 3 items and 3 rerolls' do
+        @part.tally[0].size.must_equal 3
+        @part.tally[1].size.must_equal 3
       end
     end
 


### PR DESCRIPTION
This allows for the ability to count white wolf style failures (`3d10 t8 f1`) as well as sum fudge dice nicely (`4d3 t3 f1`). This will also extend this functionality to the Dice-Maiden discord bot, which uses this library.