### PR TITLE
Add support for D1000 rolls

### DIFF
--- a/lib/dicebag/parser.rb
+++ b/lib/dicebag/parser.rb
@@ -8,7 +8,7 @@ module DiceBag
     # Base rules.
     rule(:space?)  { str(' ').repeat }
 
-    # Numbers are limited to 3 digit places. Why?
+    # Numbers are limited to 4 digit places. Why?
     # To prevent abuse from people rolling:
     # 999999999D999999999 and 'DOS'-ing the app.
     rule(:number)  { match('[0-9]').repeat(1, 4) }

--- a/lib/dicebag/parser.rb
+++ b/lib/dicebag/parser.rb
@@ -52,17 +52,18 @@ module DiceBag
     rule(:explode_indefinite) { str('ie') >> number?.as(:explode_indefinite) >> space? }
     rule(:drop)               { str('d') >> number.as(:drop) >> space? }
     rule(:keep)               { str('k') >> number.as(:keep) >> space? }
-    rule(:keeplowest)         {str('kl') >> number.as(:keeplowest) >> space?}
+    rule(:keeplowest)         { str('kl') >> number.as(:keeplowest) >> space?}
     rule(:reroll)             { str('r') >> number.as(:reroll) >> space? }
     rule(:reroll_indefinite)  { str('ir') >> number.as(:reroll_indefinite) >> space? }
     rule(:target)             { str('t') >> number.as(:target) >> space? }
     rule(:failure)            { str('f') >> number.as(:failure) >> space? }
+    rule(:botch)              { str('b') >> number.as(:botch) >> space? }
 
     # This allows options to be defined in any order and
     # even have more than one of the same option, however
     # only the last option of a given key will be kept.
     rule(:option) do
-      (drop | explode | explode_indefinite | keep | keeplowest | reroll | reroll_indefinite | target | failure )
+      (drop | explode | explode_indefinite | keep | keeplowest | reroll | reroll_indefinite | target | failure | botch )
     end
 
     rule(:options) { space? >> option.repeat >> space? }

--- a/lib/dicebag/parser.rb
+++ b/lib/dicebag/parser.rb
@@ -11,7 +11,7 @@ module DiceBag
     # Numbers are limited to 3 digit places. Why?
     # To prevent abuse from people rolling:
     # 999999999D999999999 and 'DOS'-ing the app.
-    rule(:number)  { match('[0-9]').repeat(1, 3) }
+    rule(:number)  { match('[0-9]').repeat(1, 4) }
     rule(:number?) { number.maybe }
 
     # Label rule

--- a/lib/dicebag/roll_part.rb
+++ b/lib/dicebag/roll_part.rb
@@ -180,7 +180,6 @@ module DiceBag
     end
 
     def handle_keeplowest
-
       return unless @options[:keeplowest] > 0
       range = 0...@options[:keeplowest]
 

--- a/lib/dicebag/roll_part.rb
+++ b/lib/dicebag/roll_part.rb
@@ -24,7 +24,7 @@ module DiceBag
 
       # Our Default Options
       
-      @options = { explode: 0, explode_indefinite: 0, drop: 0, keep: 0, keeplowest: 0, reroll: 0, reroll_indefinite: 0, target: 0, failure: 0 }
+      @options = { explode: 0, explode_indefinite: 0, drop: 0, keep: 0, keeplowest: 0, reroll: 0, reroll_indefinite: 0, target: 0, failure: 0, botch: 0 }
 
       @options.update(part[:options]) if part.key?(:options)
     end
@@ -91,6 +91,8 @@ module DiceBag
 
       # Keep the high end numbers if :keep is greater than zero.
       handle_keep
+
+      handle_botch
 
       # Set the total.
       handle_total
@@ -178,8 +180,16 @@ module DiceBag
     end
 
     def handle_keeplowest
+
       return unless @options[:keeplowest] > 0
       range = 0...@options[:keeplowest]
+
+      @results = @results.slice range
+    end
+
+    def handle_botch
+      return unless @options[:botch] > 0
+      range = 0...@options[:botch]
 
       @results = @results.slice range
     end

--- a/lib/dicebag/roll_part_string.rb
+++ b/lib/dicebag/roll_part_string.rb
@@ -19,6 +19,7 @@ module RollPartString
     to_s_reroll_indefinite
     to_s_target
     to_s_failure
+    to_s_botch
 
     join_str = no_spaces ? '' : ' '
 
@@ -90,5 +91,11 @@ module RollPartString
     return if @options[:failure].zero?
 
     @parts.push format('f%s', @options[:failure])
+  end
+
+  def to_s_botch
+    return if @options[:botch].zero?
+
+    @parts.push format('b%s', @options[:botch])
   end
 end

--- a/lib/dicebag/transform.rb
+++ b/lib/dicebag/transform.rb
@@ -24,6 +24,7 @@ module DiceBag
     rule(reroll_indefinite:  simple(:x)) { { reroll_indefinite: Integer(x) } }
     rule(target:  simple(:x)) { { target: Integer(x) } }
     rule(failure: simple(:x)) { { failure: Integer(x) } }
+    rule(botch:   simple(:x)) { { botch: Integer(x) } }
 
     # Explode is special, in that if it is nil, then it
     # must remain that way.


### PR DESCRIPTION
This PR is to up the max dice roll from d100 to D1000. This is important for some ttrpg game systems. This has been running fine for sometime on ~380k server discord dice bot. 

This PR also adds a botch option value for checking for botch rolls